### PR TITLE
Add Builder for UpdateQuery from JSON

### DIFF
--- a/stargate-sdk-json/src/main/java/io/stargate/sdk/json/domain/UpdateQueryBuilder.java
+++ b/stargate-sdk-json/src/main/java/io/stargate/sdk/json/domain/UpdateQueryBuilder.java
@@ -162,6 +162,20 @@ public class UpdateQueryBuilder {
     }
 
     /**
+     * Full update as a json string.
+     *
+     * @param jsonUpdate
+     *      content of the update as json
+     * @return
+     *      reference to self
+     */
+    @SuppressWarnings("unchecked")
+    public UpdateQueryBuilder withJsonUpdate(String jsonUpdate) {
+        this.update = JsonUtils.unmarshallBean(jsonUpdate, Map.class);
+        return this;
+    }
+
+    /**
      * Work with arguments.
      *
      * @param fieldName


### PR DESCRIPTION
Add an utility method to build the UpdateQuery from JSON.
Otherwise it is pretty tricky to build the UpdateQuery from a string.

This change follows the lines of `withJsonFilter`