### PR TITLE
Use UTF-8 to encode the body of requests (and not ISO-8859-1)

### DIFF
--- a/stargate-sdk-commons/src/main/java/io/stargate/sdk/http/RetryHttpClient.java
+++ b/stargate-sdk-commons/src/main/java/io/stargate/sdk/http/RetryHttpClient.java
@@ -34,6 +34,8 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URISyntaxException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -470,7 +472,10 @@ public class RetryHttpClient implements ApiConstants {
         req.addHeader(HEADER_AUTHORIZATION, "Bearer " + token);
         req.setConfig(requestConfig);
         if (null != body) {
-            req.setEntity(new StringEntity(body, ContentType.TEXT_PLAIN));
+            // If you don't set a Charset the client will use ISO-8859-1
+            // preventing the use of UNICODE characters, and also the server assumes UTF-8
+            // that lead to decoding issues.
+            req.setEntity(new StringEntity(body, ContentType.TEXT_PLAIN.withCharset(StandardCharsets.UTF_8)));
         }
         return req;
     }


### PR DESCRIPTION
This is a fix for a critical problem while dealing with the new JSON API and documents that contain characters that don't fit in the ISO-8859-1 charset.

By default the Http client encodes the body in  ISO-8859-1

This is an extract of the code of StringEntity

```
public class StringEntity extends AbstractHttpEntity {

    private final byte[] content;
    public StringEntity(
            final String string, final ContentType contentType, final String contentEncoding, final boolean chunked) {
        super(contentType, contentEncoding, chunked);
        Args.notNull(string, "Source string");
        final Charset charset = ContentType.getCharset(contentType, StandardCharsets.ISO_8859_1);
        this.content = string.getBytes(charset);
    }
    
     public StringEntity(final String string, final ContentType contentType) {
        this(string, contentType, null, false);
    }
```